### PR TITLE
Login sever side

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,14 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :basic_auth, if: :production?
 
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+    def configure_permitted_parameters
+      devise_parameter_sanitizer.permit(:sign_up, keys: [:family_name, :first_name, :family_name_kana, :first_name_kana, :nickname, :bithday, :phone_number])
+    end
+
   private
 
   def production?

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -166,7 +166,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 7..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/db/migrate/20200205065716_add_column_to_users.rb
+++ b/db/migrate/20200205065716_add_column_to_users.rb
@@ -1,0 +1,11 @@
+class AddColumnToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :family_name, :string, null: false
+    add_column :users, :first_name, :string, null: false
+    add_column :users, :family_name_kana, :string, null: false
+    add_column :users, :first_name_kana, :string, null: false
+    add_column :users, :nickname, :string, null: false
+    add_column :users, :bithday, :string, null: false
+    add_column :users, :phone_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200131110122) do
+ActiveRecord::Schema.define(version: 20200205065716) do
 
   create_table "images", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name"
@@ -26,6 +26,13 @@ ActiveRecord::Schema.define(version: 20200131110122) do
     t.datetime "remember_created_at"
     t.datetime "created_at",                          null: false
     t.datetime "updated_at",                          null: false
+    t.string   "family_name",                         null: false
+    t.string   "first_name",                          null: false
+    t.string   "family_name_kana",                    null: false
+    t.string   "first_name_kana",                     null: false
+    t.string   "nickname",                            null: false
+    t.string   "bithday",                             null: false
+    t.string   "phone_number"
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end


### PR DESCRIPTION
# What
userモデルを作成し、もともとメールアドレスとパスワードのみだったカラムに、必須入力項目のカラムを追加いたしました。また、パスワードの最低文字数を６→７に変更しました。

# Why
ユーザーの新規登録機能に必要なため