### PR TITLE
add item purchase confirmation page

### DIFF
--- a/app/assets/javascripts/purchase.coffee
+++ b/app/assets/javascripts/purchase.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/purchase.coffee
+++ b/app/assets/javascripts/purchase.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,6 +14,7 @@
 @import "my_pages";
 @import "modules/user_edit";
 @import "cards";
+@import "purchase";
 
 
 

--- a/app/assets/stylesheets/purchase.scss
+++ b/app/assets/stylesheets/purchase.scss
@@ -30,9 +30,12 @@ body{
         align-items: center;
         margin: auto;
         .item-image{
+          width: 25%;
+          height: 80px;
           &__photo{
-            width: 80px;
-            height: 80px;
+            display: inline-block;
+            width: 100%;
+            height: 100%;
           }
         }
         .item-detail{

--- a/app/assets/stylesheets/purchase.scss
+++ b/app/assets/stylesheets/purchase.scss
@@ -1,0 +1,109 @@
+body{
+  background: #f5f5f5;
+}
+
+.main-container{
+  width: 100%;
+  .buy-container{
+    background-color: #fff;
+    width: 50%;
+    margin: auto;
+    &__head{
+      font-size: 22px;
+      padding: 32px;
+      line-height: 1.5;
+      text-align: center;
+      font-weight: bold;
+    }
+    &__item{
+      border-top: 0.5px solid #f5f5f5;
+      border-bottom: 0.5px solid #f5f5f5; 
+      width: 100%;
+      height: 150px;
+      display: flex;
+      &--inner{
+        width: 50%;
+        height: 100%;
+        margin-left: 25%;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        margin: auto;
+        .item-image{
+          &__photo{
+            width: 80px;
+            height: 80px;
+          }
+        }
+        .item-detail{
+          padding-left: 50px;
+          &__name{
+            font-size: 14px;
+            padding: 8px;
+          }
+          &__price{
+            display: flex;
+            padding: 8px;
+            .item-price{
+              font-size: 15px;
+            }
+            .item-fee{
+              font-size: 15px;
+            }
+          }
+        }
+      }
+    }
+    
+    &__pay{
+      height: 150px;
+      .buy-price{
+        width: 100%;
+        display: flex;
+        justify-content: space-between;
+        &__label{
+          font-size: 20px;
+        }
+        &__pay{
+          font-size: 20px;
+        }
+      }
+    }
+    &__way{
+      height: 150px;
+    }
+    &__Shipping-address{
+      height: 150px;
+      }
+    &__form{
+      height: 100px;
+      width: 50%;
+      margin: auto;
+      padding-top: 20px;
+      .buy-btn{
+        background: #888;
+        color: #fff;
+        display: inline-block;
+        height: 50px;
+        width: 100%;
+        line-height: 50px;
+        font-size: 14px;
+        text-align: center;
+      }
+    }
+  }
+}  
+
+.buy-content-inner{
+  width: 50%;
+  height: 100%;
+  margin: auto;
+  border-bottom: 0.5px solid #f5f5f5;
+  display: flex;
+  align-items: center;
+}
+
+i,a{
+  color: #0099e8;
+  text-decoration: none;
+}

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -1,0 +1,7 @@
+class PurchaseController < ApplicationController
+  def index
+  end
+
+  def done
+  end
+end

--- a/app/helpers/purchase_helper.rb
+++ b/app/helpers/purchase_helper.rb
@@ -1,0 +1,2 @@
+module PurchaseHelper
+end

--- a/app/views/purchase/done.html.haml
+++ b/app/views/purchase/done.html.haml
@@ -1,0 +1,2 @@
+%h1 Purchase#done
+%p Find me in app/views/purchase/done.html.haml

--- a/app/views/purchase/done.html.haml
+++ b/app/views/purchase/done.html.haml
@@ -1,2 +1,1 @@
-%h1 Purchase#done
-%p Find me in app/views/purchase/done.html.haml
+%h2 購入が完了しました！

--- a/app/views/purchase/index.html.haml
+++ b/app/views/purchase/index.html.haml
@@ -6,7 +6,7 @@
     .buy-container__item
       .buy-container__item--inner
         .item-image
-          %img.item-image__photo{src: "#"}
+          = image_tag "#", class: "tem-image__photo"
         .item-detail
           .item-detail__name ああああ
           .item-detail__price

--- a/app/views/purchase/index.html.haml
+++ b/app/views/purchase/index.html.haml
@@ -1,0 +1,41 @@
+=render "items/ease-header"
+
+.main-container
+  .buy-container
+    .buy-container__head 購入内容の確認
+    .buy-container__item
+      .buy-container__item--inner
+        .item-image
+          %img.item-image__photo{src: "#"}
+        .item-detail
+          .item-detail__name ああああ
+          .item-detail__price
+            .item-price ¥3,000
+            .item-fee（税込）送料込み
+    .buy-container__pay
+      .buy-content-inner
+        .buy-price
+          .buy-price__label 支払い金額
+          .buy-price__pay ¥3,000
+    
+    .buy-container__way
+      .buy-content-inner
+        .pay-way
+          .pay-way__label 支払い方法
+          .buy-register-text
+            %i.fas.fa-plus-circle
+            =link_to '登録してください', '#'
+          
+
+    .buy-container__Shipping-address
+      .buy-content-inner
+        .Shipping-address
+          .Shipping-address__label 発送先
+          .buy-register-text
+            %i.fas.fa-plus-circle
+            =link_to '登録してください', '#'
+                  
+    .buy-container__form
+      =link_to '購入する', '#', class:'buy-btn'
+
+=render "items/ease-footer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
+  get 'purchase/index'
+
+  get 'purchase/done'
+
   devise_for :users
   
   root "items#index"
@@ -15,5 +19,6 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :purchase, only: [:index]
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,5 @@
 Rails.application.routes.draw do
-  get 'purchase/index'
-
-  get 'purchase/done'
-
+  
   devise_for :users
   
   root "items#index"
@@ -19,6 +16,14 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :purchase, only: [:index]
+  #クレジット購入で今後、使用   
+  resources :purchase, only: [:index] do
+    collection do
+      get 'index', to: 'purchase#index'
+      # post 'pay', to: 'purchase#pay'
+      get 'done', to: 'purchase#done'
+    end
+  end
+  
 
 end

--- a/spec/controllers/purchase_controller_spec.rb
+++ b/spec/controllers/purchase_controller_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe PurchaseController, type: :controller do
+
+  describe "GET #index" do
+    it "returns http success" do
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET #done" do
+    it "returns http success" do
+      get :done
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/helpers/purchase_helper_spec.rb
+++ b/spec/helpers/purchase_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the PurchaseHelper. For example:
+#
+# describe PurchaseHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe PurchaseHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/purchase/done.html.haml_spec.rb
+++ b/spec/views/purchase/done.html.haml_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "purchase/done.html.haml", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/purchase/index.html.haml_spec.rb
+++ b/spec/views/purchase/index.html.haml_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "purchase/index.html.haml", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# What
購入確認ページのフロント実装
link先等は今後実装

[![Screenshot from Gyazo](https://gyazo.com/91a9838ae702bcabc2553d548f4d7939/raw)](https://gyazo.com/91a9838ae702bcabc2553d548f4d7939)

# Why
購入確定前の確認を行うため。
